### PR TITLE
Bumping AWS Provider Version | Is-23235

### DIFF
--- a/streamalert_cli/_infrastructure/_include.tf
+++ b/streamalert_cli/_infrastructure/_include.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 4.9.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/streamalert_cli/_infrastructure/modules/tf_cloudwatch_logs_destination/modules/destination/main.tf
+++ b/streamalert_cli/_infrastructure/modules/tf_cloudwatch_logs_destination/modules/destination/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = ">= 4.0.0, < 4.9.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }


### PR DESCRIPTION
- Bumping the higher limit for AWS provider version from 4.9.0 to 5.0.0
- Tested in Dev Streamalert