### PR TITLE
DynamoDB IAM permissions

### DIFF
--- a/streamalert/shared/lookup_tables/driver_dynamodb.py
+++ b/streamalert/shared/lookup_tables/driver_dynamodb.py
@@ -58,7 +58,7 @@ class DynamoDBDriver(PersistenceDriver):
 
         super(DynamoDBDriver, self).__init__(configuration)
 
-        self._dynamo_db_table = configuration['table'].split('/')[0]
+        self._dynamo_db_table = configuration['table']
         self._dynamo_db_index = configuration.get('index')
         self._dynamo_db_partition_key = configuration['partition_key']
         self._dynamo_db_value_key = configuration['value_key']

--- a/streamalert_cli/terraform/generate.py
+++ b/streamalert_cli/terraform/generate.py
@@ -569,6 +569,12 @@ def _generate_lookup_tables_settings(config):
 
         if table_config['driver'] == 'dynamodb':
             dynamodb_tables.add(table_config['table'])
+
+            # Generates ARN for global secondary index for a dynamodb table
+            index = table_config.get('index', '')
+            if index:
+                dynamodb_tables.add(f"{table_config['table']}/index/{index}")
+
             continue
 
     if not dynamodb_tables and not s3_buckets:


### PR DESCRIPTION
- Allows StreamAlert to autogenerate required IAM permissions to query DynamoDB global secondary index
- https://ridgelineapps.atlassian.net/browse/IS-23233