### PR TITLE
fix(IS-24575) GitHub test schema

### DIFF
--- a/conf/schemas/ghce.json
+++ b/conf/schemas/ghce.json
@@ -1,4 +1,10 @@
 {
+    "ghce:test": {
+        "parser": "csv",
+        "schema": {
+            "message": "string"
+        }
+    },
     "ghce:cloud": {
         "schema": {
             "@timestamp": "integer",


### PR DESCRIPTION
Adds a schema to avoid "Github audit log stream check" failed parse errors.